### PR TITLE
Wind charge damage type correction

### DIFF
--- a/1.20.5/23w51a.md
+++ b/1.20.5/23w51a.md
@@ -8,7 +8,7 @@ attribute | Added attribute `generic.step_height`, which controls the maximum nu
 
 damage-type | Added damage type `spit`, which llamas now use instead of `mob_projectile`.
 
-damage-type | Added experimental damage type `wind_charge`.
+damage-type | Added damage type `wind_charge`.
 
 data tag damage-type | Added damage type tag `always_kills_armor_stands`
 

--- a/1.20.5/24w04a.md
+++ b/1.20.5/24w04a.md
@@ -2,8 +2,6 @@ pack breaking | Data pack format has been increased to 29.
 
 command | Added the `/transfer` command to transfer players to another server. It has syntax `/transfer <hostname> [<port>] [<players>]`.
 
-damage-type obsolete | Added damage type `wind_charge`
-
 storage options | The chunk compression mode can be configured with the `region-file-compression` option in `server.properties`. Possible values: `deflate` (default) and `lz4`.
 
 storage | Added startup flag `recreateRegionFiles`, which will optimize and rewrite all the region files.

--- a/1.20.5/24w05a.md
+++ b/1.20.5/24w05a.md
@@ -2,8 +2,6 @@ pack breaking | Data pack format has been increased to 30.
 
 pack breaking | Resource pack format has been increased to 30.
 
-damage-type obsolete | Removed damage type `wind_charge`
-
 data tag | Added entity type tag `no_anger_from_wind_charge`.
 
 data tag | Added item tag `dyeable`.


### PR DESCRIPTION
The `wind_charge` damage type was not removed, it was just moved into the 1.21 datapack. You can see that [here](https://github.com/misode/mcmeta/blob/data/data/minecraft/datapacks/update_1_21/data/minecraft/damage_type/wind_charge.json).