### PR TITLE
25w07a and 25w08a Changelogs

### DIFF
--- a/1.21.5/25w05a.md
+++ b/1.21.5/25w05a.md
@@ -10,6 +10,8 @@ tag data breaking obsolete | Renamed damage type tag `#bypasses_blocking` to `#b
 
 variant | Cow variants can now be data-driven, with entries in the `cow_variant` folder. The file takes fields `model` (one of `normal`, `cold`, and `warm`), `asset_id`, and `spawn_conditions`.
 
+entity item component | Added entitiy and item component `cow/variant`, a namespaced id from `cow_variant` registry
+
 item component | The item component `blocks_attacks` has two new fields:
 * `bypassed_by` - A damage type tag that prevents the item from blocking when present
 * Subfield `horizontal_blocking_angle` in `damage_reductions` - A positive float defining the maximum angle between the user's facing and incoming attack to successfully block the attack

--- a/1.21.5/25w05a.md
+++ b/1.21.5/25w05a.md
@@ -10,7 +10,7 @@ tag data breaking obsolete | Renamed damage type tag `#bypasses_blocking` to `#b
 
 variant | Cow variants can now be data-driven, with entries in the `cow_variant` folder. The file takes fields `model` (one of `normal`, `cold`, and `warm`), `asset_id`, and `spawn_conditions`.
 
-entity item component | Added entitiy and item component `cow/variant`, a namespaced id from `cow_variant` registry
+entity item component | Added data component `cow/variant`, a namespaced id from the `cow_variant` registry.
 
 item component | The item component `blocks_attacks` has two new fields:
 * `bypassed_by` - A damage type tag that prevents the item from blocking when present

--- a/1.21.5/25w06a.md
+++ b/1.21.5/25w06a.md
@@ -1,6 +1,6 @@
-pack breaking | Data pack format has been increased to 66.
+pack breaking obsolete | Data pack format has been increased to 66.
 
-pack breaking | Resource pack format has been increased to 51.
+pack breaking obsolete | Resource pack format has been increased to 51.
 
 gamerule | Added `allowFireTicksAwayFromPlayer` gamerule, which defaults to `false`. When `true`, lava and fire ticks may occur outside of an 8 chunk range from a player.
 

--- a/1.21.5/25w06a.md
+++ b/1.21.5/25w06a.md
@@ -14,4 +14,6 @@ entity data | The player's armor and off-hand equipment is now also stored in th
 
 variant | Chicken variants can now be data-driven, with entries in the `chicken_variant` folder. The file takes fields `model` (one of `normal`, `cold`, and `warm`), `asset_id`, and `spawn_conditions`.
 
+entity item component | Added entitiy and item component `chicken/variant`, a namespaced id from `chicken_variant` registry
+
 assets texture breaking | Moved texture `entity/chicken.png` to `entity/chicken/temperate_chicken.png`.

--- a/1.21.5/25w06a.md
+++ b/1.21.5/25w06a.md
@@ -14,6 +14,6 @@ entity data | The player's armor and off-hand equipment is now also stored in th
 
 variant | Chicken variants can now be data-driven, with entries in the `chicken_variant` folder. The file takes fields `model` (one of `normal`, `cold`, and `warm`), `asset_id`, and `spawn_conditions`.
 
-entity item component | Added entitiy and item component `chicken/variant`, a namespaced id from `chicken_variant` registry
+entity item component | Added entity and item component `chicken/variant`, a namespaced id from `chicken_variant` registry.
 
 assets texture breaking | Moved texture `entity/chicken.png` to `entity/chicken/temperate_chicken.png`.

--- a/1.21.5/25w07a.md
+++ b/1.21.5/25w07a.md
@@ -6,9 +6,9 @@ entity predicate | The entity predicate `stepping_on` can now only evaluate to `
 
 tag data | Added block tag `#camels_spawnable_on`, which contains blocks camels can spawn on.
 
-tag data | Added structure tag `#on_<biome>_village_maps`, which contains structures that can spawn on Explorer Maps for that type, where `<biome>` is one of `savanna`, `desert`, `plains`, `taiga`, `snowy`, `swamp`, and `jungle`.
+tag data | Added structure tag `#on_<biome>_village_maps`, which contains structures that can spawn on explorer maps for that type, where `<biome>` is one of `savanna`, `desert`, `plains`, `taiga`, `snowy`, `swamp`, and `jungle`.
 
-entity data breaking | The `Pos`, `Motion` and `Rotation` entity data fields must take the correct number of components in their values (3, 3, and 2, respectively). If the correct number is not present, the data will now be discared.
+entity data breaking | The `Pos`, `Motion` and `Rotation` entity data fields must take the correct number of components (3, 3, and 2, respectively), otherwise the data will now be discared.
 
 entity data breaking | The `SleepingX`, `SleepingY`, and `SleepingZ` entity data fields have been removed and combined into a single `sleeping_pos` field, which takes an array of three ints.
 
@@ -61,12 +61,12 @@ assets breaking | Mooshroom models now have a snout.
 
 shader breaking | Shader program definitions in JSON files for core shaders and post-processing effects have been removed.
 
-shader breaking | The `program` is removed and replaced by `vertex_shader` and `fragment_shader`. `<namespace>:<path>` will resolve to `assets/<namespace>/shaders/<path>.<vsh|fsh>`.
+shader breaking | Removed field `program` in shader definitions and replaced it with fields `vertex_shader` and `fragment_shader`, where `<namespace>:<path>` will resolve to `assets/<namespace>/shaders/<path>.<vsh|fsh>`.
 
 shader breaking | In each `uniform`, the `type` field is now required, accepting value types of any `int`, `ivec3`, `float`, `vec2`, `vec3`, `vec4`, and `matrix4`.
 
-shader | In each uniform`, the `values` field is now optional.
+shader | In each uniform, the `values` field is now optional.
 
-rendering | The `firstperson_lefthand` and `thirdperson_lefthand` item rendering transforms are now rendered the same when held in hand.
+entity | The `firstperson_lefthand` and `thirdperson_lefthand` transforms of item display entities are now rendered the same as when held in hand.
 
-rendering | When an item or item stack entity is on the ground, model size is taken into account when deciding the hovering motion, preventing the item entity from clipping into the block below it.
+entity | When an item stack entity is on the ground, model size is taken into account when deciding the hovering motion, preventing the item entity from clipping into the block below it.

--- a/1.21.5/25w07a.md
+++ b/1.21.5/25w07a.md
@@ -1,0 +1,72 @@
+pack breaking obsolete | Data pack format has been increased to 67.
+
+pack breaking obsolete | Resource pack format has been increased to 52.
+
+entity predicate | The entity predicate `stepping_on` can now only evaluate to `true` if the entity is on the ground.
+
+tag data | Added block tag `#camels_spawnable_on`, which contains blocks camels can spawn on.
+
+tag data | Added structure tag `#on_<biome>_village_maps`, which contains structures that can spawn on Explorer Maps for that type, where `<biome>` is one of `savanna`, `desert`, `plains`, `taiga`, `snowy`, `swamp`, and `jungle`.
+
+entity data breaking | The `Pos`, `Motion` and `Rotation` entity data fields must take the correct number of components in their values (3, 3, and 2, respectively). If the correct number is not present, the data will now be discared.
+
+entity data breaking | The `SleepingX`, `SleepingY`, and `SleepingZ` entity data fields have been removed and combined into a single `sleeping_pos` field, which takes an array of three ints.
+
+entity data | Block states defined in entity data of arrows, minecarts, block displays, endermen, falling blocks, primed tnt, and piston moving blocks can no longer be defined as an empty object.
+
+entity data | The following entity data fields will no longer stay persistent when removed via `/data` or other data modification methods:
+* fox: `Trusted`
+* item: `Owner` and `Thrower`
+* shulker bullet: `Dir` and `Target`
+* villager and zombie villager: `Gossips`
+* wandering trader: `wander_target`
+* evoker fangs, area of effect cloud, and all projectiles: `Owner`
+* arrow, spectral arrow, and trident: `inBlockState` and `SoundEvent`
+* block, item, and text displays: `glow_color_override`
+* witch, ravager, pillager, illusioner, evoker, and vindicator: `patrol_target`
+
+entity data | Removed the `CanDuplicate` field in allay entity data, as it is already controlled via `DuplicationCooldown`.
+
+entity data | The `CollarColor` field in cat and dog entity data defaults to `14` (red) if not specified.
+
+entity data breaking | Removed the `TreasurePosX`, `TreasurePosY`, and `TreasurePosZ` fields in dolphin entity data.
+
+entity data | The `BlockState` field in falling block entity data can be defined as `air`, and defaults to `sand` if invalid or unspecified.
+
+entity data | The `Trusted` field in fox entity data now defaults to empty if not specified.
+
+entity data breaking | For phantom entity data, the `Size` field is renamed to `size`, and `AX`, `AY`, and `AZ` fields are removed and combined into a single `anchor_pos` field.
+
+entity data breaking | For player entity data, the `SpawnX`, `SpawnY`, `SpawnZ`, `SpawnAngle`, `SpawnDimension`, and `SpawnForced` fields are removed and combined into a single `respawn` object field. The object has fields `pos`, `angle`, `dimension`, and `forced`.
+
+entity data breaking | For player entity data, the `enteredNetherPosition` field is renamed to `entered_nether_pos`, and now takes a list of doubles.
+
+entity data | The `block_state` field in primed tnt entity data now defaults to `tnt` if not specified.
+
+entity data breaking | For turtle entity data, the `HasEgg` field is renamed to `has_egg`; the `HomePosX`, `HomePosY`, and `HomePosZ` fields are removed and combined into a single `home_pos` field; and the `TravelPosX`, `TravelPosY`, and `TravelPosZ` field are removed.
+
+entity data breaking | For vex entity data, the `LifeTicks` is renamed to `life_ticks`, and the `BoundX`, `BoundY`, and `BoundZ` fields are removed and combined into a single `bound_pos` field.
+
+entity data breaking | For item frame, glow item frame, and leash knot entity data, the `TileX`, `TileY`, and `TileZ` fields are removed and combined into a single `block_pos` field.
+
+entity data breaking | For minecart and minecart adjacent entity data, the `CustomDisplayTile` field is removed, the `DisplayState` field will always override the default displayed block state when specified, and `DisplayOffset` can now override the default offset even if a custom display block state set is not specified.
+
+block data | The following block data fields will no longer stay persistent when removed via `/data` or other data modification methods:
+* all applicable: `CustomName` and `LootTable`
+* end gateway: `exit_portal`
+* furnace, smoker, and blast furnace: `RecipesUsed`
+* skull: `note_block_sound`
+
+assets breaking | Mooshroom models now have a snout.
+
+shader breaking | Shader program definitions in JSON files for core shaders and post-processing effects have been removed.
+
+shader breaking | The `program` is removed and replaced by `vertex_shader` and `fragment_shader`. `<namespace>:<path>` will resolve to `assets/<namespace>/shaders/<path>.<vsh|fsh>`.
+
+shader breaking | In each `uniform`, the `type` field is now required, accepting value types of any `int`, `ivec3`, `float`, `vec2`, `vec3`, `vec4`, and `matrix4`.
+
+shader | In each uniform`, the `values` field is now optional.
+
+rendering | The `firstperson_lefthand` and `thirdperson_lefthand` item rendering transforms are now rendered the same when held in hand.
+
+rendering | When an item or item stack entity is on the ground, model size is taken into account when deciding the hovering motion, preventing the item entity from clipping into the block below it.

--- a/1.21.5/25w08a.md
+++ b/1.21.5/25w08a.md
@@ -2,18 +2,18 @@ pack breaking | Data pack format has been increased to 68.
 
 pack breaking | Resource pack format has been increased to 53.
 
-variant | Added data-driven wolf sound variants, with entries in the `wolf_sound_variant` folder. The file takes fields `ambient_sound`, `death_sound`, `growl_sound`, `hurt_sound`, `pant_sound`, and `whine_sound`, which point to a sound. Wolf sound variants are randomly applied to all wolves, and wolf variant is not taken into account.
+variant | Added data-driven wolf sound variants, with entries in the `wolf_sound_variant` folder. The file takes fields `ambient_sound`, `death_sound`, `growl_sound`, `hurt_sound`, `pant_sound`, and `whine_sound`, which point to a sound event. Wolf sound variants are randomly applied to all wolves independent of the texture variant.
 
-worldgen | Added optional `effects` field `dry_foliage_color` in the biome definition, which defines the tinting color for leaf litter and other dry foliage blocks.
+worldgen | Added optional field `dry_foliage_color` in the biome effects, which defines the tinting color for leaf litter and other dry foliage blocks.
 
-entity component | Added entitiy component `wolf/sound_variant`, a namespaced id from `wolf_sound_variant` registry.
+entity component | Added entity component `wolf/sound_variant`, a namespaced id from `wolf_sound_variant` registry.
 
 item component | When using the `blocks_attacks` item component, if the blocked damage has no position, the compared angle will default to `180` for the `horizontal_blocking_angle` field in `damage_reductions`.
 
-assets | Added the posibility to tint blocks based on a dry foliage color map.
+assets | Added the possibility to tint blocks based on a dry foliage color map.
 
-assets sound | Added sounds for the `big`, `cute`, `puglin`, `angry`, `grumpy`, and `sad` wolf sound wolf variants.
+assets sound | Added sounds for the `big`, `cute`, `puglin`, `angry`, `grumpy`, and `sad` wolf sound variants.
 
 assets sound breaking | The sound files for the classic wolf sound variant are moved under the `classic` subdirectory.
 
-assets sound breaking | Removed the `howl` wolf sound.
+assets sound breaking | Removed the `entity.wolf.howl` sound event.

--- a/1.21.5/25w08a.md
+++ b/1.21.5/25w08a.md
@@ -1,0 +1,19 @@
+pack breaking | Data pack format has been increased to 68.
+
+pack breaking | Resource pack format has been increased to 53.
+
+variant | Added data-driven wolf sound variants, with entries in the `wolf_sound_variant` folder. The file takes fields `ambient_sound`, `death_sound`, `growl_sound`, `hurt_sound`, `pant_sound`, and `whine_sound`, which point to a sound. Wolf sound variants are randomly applied to all wolves, and wolf variant is not taken into account.
+
+worldgen | Added optional `effects` field `dry_foliage_color` in the biome definition, which defines the tinting color for leaf litter and other dry foliage blocks.
+
+entity component | Added entitiy component `wolf/sound_variant`, a namespaced id from `wolf_sound_variant` registry.
+
+item component | When using the `blocks_attacks` item component, if the blocked damage has no position, the compared angle will default to `180` for the `horizontal_blocking_angle` field in `damage_reductions`.
+
+assets | Added the posibility to tint blocks based on a dry foliage color map.
+
+assets sound | Added sounds for the `big`, `cute`, `puglin`, `angry`, `grumpy`, and `sad` wolf sound wolf variants.
+
+assets sound breaking | The sound files for the classic wolf sound variant are moved under the `classic` subdirectory.
+
+assets sound breaking | Removed the `howl` wolf sound.

--- a/tags.json
+++ b/tags.json
@@ -43,6 +43,7 @@
     "poi": "Any changes to the POI system",
     "predicate": "Anything regarding predicates (overreaches `advancement` and `loot`",
     "recipe": "Changes to the recipe system",
+    "rendering": "Changes to entity, item, block, or etc. rendering",
     "scoreboard": "New statistics or scoreboard command changes",
     "shader": "Shader type changes",
     "sound": "`assets` changes specifically for sound events",

--- a/tags.json
+++ b/tags.json
@@ -43,7 +43,6 @@
     "poi": "Any changes to the POI system",
     "predicate": "Anything regarding predicates (overreaches `advancement` and `loot`",
     "recipe": "Changes to the recipe system",
-    "rendering": "Changes to entity, item, block, or etc. rendering",
     "scoreboard": "New statistics or scoreboard command changes",
     "shader": "Shader type changes",
     "sound": "`assets` changes specifically for sound events",


### PR DESCRIPTION
Added changelogs for 25w07a and 25w08a. Yes, my branch is named 25w07a, got lazy after the 1 day delay last week :)

Only special thing to note was some things I listed in 25w07a. I created a new `rendering` tag, which is used in the last two bullet points in the 25w07a changelog. However, I'm unsure if it is relevant to these changelogs. If not, feel free to remove it.