### PR TITLE
25w09a add AEC default radius change

### DIFF
--- a/1.21.5/25w09a.md
+++ b/1.21.5/25w09a.md
@@ -62,6 +62,8 @@ entity data | The area effect cloud's `Duration` field now defaults to -1 if not
 
 entity data | If an area effect cloud's `Duration` field is -1, it will never run out.
 
+entity data | The area effect cloud's `Radius` field now defaults to 3.0f if not specified.
+
 entity data | The creeper's `Fuse` field now defaults to 30, and its `ExplosionRadius` field now defaults to 3 if not specified.
 
 entity data | The dolphin's `Moistness` field now defaults to 2400 if not specified.


### PR DESCRIPTION
In 25w09a, the area effect cloud was changed to have a default radius of 3.0f instead of 0.0f when not specified.