### PR TITLE
Finish 1.21.5 Changelogs

### DIFF
--- a/1.21.5/1.21.5-pre1.md
+++ b/1.21.5/1.21.5-pre1.md
@@ -1,0 +1,9 @@
+pack breaking | Resource pack format has been increased to 71.
+
+pack breaking | Resource pack format has been increased to 55.
+
+command obsolete | Command arguments that accept inline values have been reverted to accept numbers in place of booleans.
+
+network | The clientbound `player_chat` packet now contains an index for every message sent. It starts at 0 upon logging in, and the client will disconenct if there is a mismatch.
+
+network | The serverbound `chat` and `chat_command_signed` packets now contain a checksum byte.

--- a/1.21.5/25w05a.md
+++ b/1.21.5/25w05a.md
@@ -16,6 +16,8 @@ item component | The item component `blocks_attacks` has two new fields:
 * `bypassed_by` - A damage type tag that prevents the item from blocking when present
 * Subfield `horizontal_blocking_angle` in `damage_reductions` - A positive float defining the maximum angle between the user's facing and incoming attack to successfully block the attack
 
+worldgen breaking | The order of the `patch_pumpkin` and `patch_sugar_cane` features has been swapped in all biomes.
+
 assets texture breaking | Renamed texture `pig` to `temperate_pig`.
 
 assets texture breaking | Renamed texture `cow` to `temperate_cow`.

--- a/1.21.5/25w08a.md
+++ b/1.21.5/25w08a.md
@@ -1,6 +1,6 @@
 pack breaking obsolete | Data pack format has been increased to 68.
 
-pack breaking | Resource pack format has been increased to 53.
+pack breaking obsolete | Resource pack format has been increased to 53.
 
 variant | Added data-driven wolf sound variants, with entries in the `wolf_sound_variant` folder. The file takes fields `ambient_sound`, `death_sound`, `growl_sound`, `hurt_sound`, `pant_sound`, and `whine_sound`, which point to a sound event. Wolf sound variants are randomly applied to all wolves independent of the texture variant.
 

--- a/1.21.5/25w09a.md
+++ b/1.21.5/25w09a.md
@@ -1,4 +1,4 @@
-pack breaking | Data pack format has been increased to 69. Nice!
+pack breaking obsolete | Data pack format has been increased to 69. Nice!
 
 command | `/data` command can now create and modify heterogeneous lists transparently, and can no longer traverse paths with an empty key (e.g. `/data get ... foo.''.bar`).
 

--- a/1.21.5/25w10a.md
+++ b/1.21.5/25w10a.md
@@ -1,0 +1,17 @@
+pack breaking obsolete | Data pack format has been increased to 70.
+
+pack breaking obsolete | Resource pack format has been increased to 54.
+
+data entity | Added `custom_data` entity component with a `data` field to all entities. Stored only when non-empty.
+
+predicate entity | Added optional `predicates` field to entity predicates to match partial contents on entity components. Functionality and format is identical to item predicates' `predicates` field.
+
+predicate block | Added optional `components` and `predicates` fields to block predicates to match exact and partial contents on entity components, respectively. Functionality and format is identical to item predicates' `predicates` field.
+
+nbt | Added `bool(arg)` and `uuid(str)` operations to SNBT.
+
+nbt breaking | Implicit inline float values in SNBT (such as `1e1000`) are now rejected.
+
+gamerule | Added `tntExplodes` gamerule, which defaults to `true`. When `false`, tnt cannot explode nor be primed.
+
+shader | Global uniforms may be defined in any shader. The type of uniform must match what it would normally be.


### PR DESCRIPTION
Added the changelogs for 25w10a and 1.21.5-pre1.

Additionally, although it was not written in the official changelogs, I added the breaking change that occurred in 25w05a where two features were swapped, causing a FOC if worldgen developers did not catch it in their own biomes.

I'll work on 1.21.6 changelogs soon :tm:  :)